### PR TITLE
Reducing model size by 50%

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,5 +15,5 @@ $ make test
 
 ```bash
 $ scripts/upload-to-pypi test
-$ scripts/upload-to-pypi
+$ scripts/upload-to-pypi main
 ```

--- a/gibberish_detector/model.py
+++ b/gibberish_detector/model.py
@@ -1,5 +1,6 @@
 import math
 from typing import Any
+from typing import cast
 from typing import Dict
 from typing import Optional
 from typing import Union
@@ -32,8 +33,11 @@ class Model:
         """
         :param data: the `json()` representation for this model.
         """
-        model = cls(data['charset'], data.get('ngram_size', 2))
-        model.data = data['counts']
+        model = cls(
+            cast(str, data['charset']),
+            int(cast(str, data.get('ngram_size', 2))),
+        )
+        model.data = cast(Dict[str, Dict[str, float]], data['counts'])
 
         return model
 
@@ -57,7 +61,7 @@ class Model:
         # reset cache
         self._normalized_model = None
 
-    def json(self) -> Dict[str, Union[str, int, Dict[str, float]]]:
+    def json(self) -> Dict[str, Union[str, int, Dict[str, Dict[str, float]]]]:
         """
         This outputs a reversible representation for the model.
         Use this function for serialization, but the `normalize` function for detection.

--- a/gibberish_detector/serializer.py
+++ b/gibberish_detector/serializer.py
@@ -1,29 +1,28 @@
 """
+The purpose of the serializer is to compress the `model.json()` for saving to disk.
 Downstream users should not depend on the precise implementations of these serialization functions.
 We only assert that:
 
->>> payload == deserialize(serialize(payload))
+>>> model == deserialize(serialize(model))
 """
+import json
+
 from .exceptions import ParsingError
 from .model import Model
 
 
 def serialize(model: Model) -> str:
-    # Let's just use the most straight-forward serialization model right now.
-    # We can always optimize it later.
-    import json
-    return json.dumps(model.json())
+    data = model.json()
+    return json.dumps(data)
 
 
 def deserialize(payload: str) -> Model:
     """
     :raises: ParsingError
     """
-    import json
-
     try:
-        data = json.loads(payload)
+        raw_data = json.loads(payload)
     except json.decoder.JSONDecodeError:
         raise ParsingError
 
-    return Model.from_dict(data)
+    return Model.from_dict(raw_data)

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -30,11 +30,33 @@ def test_basic(basic_model_filename, text, is_gibberish):
     assert (output.read().strip() == 'True') is is_gibberish
 
 
-def test_train_on_multiple_files(basic_model_filename):
+def test_update_model(basic_model_filename):
     # This is a smoke test
-    assert main([
-        'train', 'examples/quote.txt', '--amend', basic_model_filename,
-    ]) == 0
+    with tempfile.NamedTemporaryFile('w+') as f:
+        with redirect_stdout(f):
+            assert main([
+                'train', 'examples/quote.txt', '--amend', basic_model_filename,
+            ]) == 0
+
+        f.seek(0)
+        with open(basic_model_filename) as g:
+            assert f.read() != g.read()
+
+
+def test_train_multiple_models():
+    with tempfile.NamedTemporaryFile('w+') as f, tempfile.NamedTemporaryFile('w+') as g:
+        with redirect_stdout(f):
+            assert main(
+                'train examples/big.txt examples/quote.txt'.split(),
+            ) == 0
+
+        with redirect_stdout(g):
+            assert main('train examples/quote.txt'.split()) == 0
+
+        f.seek(0)
+        g.seek(0)
+
+        assert f.read() != g.read()
 
 
 def test_interactive(basic_model_filename):

--- a/tests/serializer_test.py
+++ b/tests/serializer_test.py
@@ -5,29 +5,20 @@ from gibberish_detector.model import Model
 
 
 @pytest.mark.parametrize(
-    'model',
+    'line',
     (
         # Basic case
-        {
-            'a': {'a': 2.0},
-        },
+        'aaaaaaaaaa',
 
         # Nested with multiple values
-        {
-            'a': {'a': 1.1, 'b': 1.2},
-        },
+        'aaaaaaaaab',
 
         # Multiple top level
-        {
-            'a': {'a': 2.0},
-            'b': {'b': 2.0},
-        },
-        {
-            'a': {'a': 1.1, 'b': 1.2},
-            'b': {'a': 0.9, 'b': 1.4},
-        },
+        'aaaaabbbbb',
+        'aabbaabbaa',
     ),
 )
-def test_success(model):
-    model = Model.from_dict(model)
+def test_success(line):
+    model = Model('ab')
+    model.train(line)
     assert model == serializer.deserialize(serializer.serialize(model))


### PR DESCRIPTION
## Summary

This PR introduces two features:

1. Model Size Reduction
2. Model Configurability

### Model Size Reduction

I made the realization that the model did not need to be normalized, when it gets saved to disk. Instead, it just needs to be normalized before using it for analysis. As such, we can keep around the raw counts (storing integers, rather than long logarithmic floats), which reduces the model size.

```bash
$ git checkout HEAD~1
$ gibberish-detector train examples/big.txt > big.old.model
$ git checkout feature/reducing-model-size
$ gibberish-detector train examples/big.txt > big.new.model
$
$ du big.old.model
68K     big.old.model
$ du big.new.model
32K     big.new.model
```

That's a pretty good reduction!

### Model Configurability

This cleans up some of the old TODOs lying around. The idea is that the model should be an abstraction, and allow the configurability of character sets (so we can support case-sensitivity really easily). Furthermore, it might come in useful to experiment with differing ngram lengths, since the basic premise is the same.

Now, the JSON representation of the model will carry these information with it, so that the model can be recreated (accurately) from its JSON representation.