### PR TITLE
make training large corpuses runnable from project root

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ True
 **Training Large Corpuses**:
 
 ```bash
-$ gibberish-detector train $(ls examples) > generic.model
+$ gibberish-detector train $(ls examples/*) > generic.model
 ```
 
 **Interactive Detection**:


### PR DESCRIPTION
Hi! 

Thank you for your great work to adapt this fantastic repo to py3! 

I found that the original command for training large corpuses, `gibberish-detector train $(ls examples) > generic.model` is not runnable from the project root.

To replicate this problem:
When running:
`gibberish-detector train $(ls examples) > generic.model`
The following error will occur:
`usage: gibberish-detector train [-h] [--amend AMEND] filename [filename ...]`
`gibberish-detector train: error: argument filename: Invalid file: big.txt`

Hence I propose changing the original command to the following to make it runnable from the project root:
`gibberish-detector train $(ls examples/*) > generic.model`

Thank you,
Huan